### PR TITLE
fix `chk_dest` expand user

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -170,9 +170,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "EntryPoint"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -243,15 +241,12 @@
     {
      "data": {
       "text/plain": [
-       "{'pyskills.edit': 'Text editing tools for modifying files and ipynb notebook cells. Each operation — insert, replace, delete lines, and string replacement — has both a `file_*` and `cell_*` variant. All return unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
-       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.',\n",
-       " 'test.skill': 'A test skill.'}"
+       "{'pyskills.edit': 'Text editing tools for modifying files and ipynb notebook cells. Each operation — insert, replace, delete lines, and string(s) replacement — has both a `file_*` and `cell_*` variant. All return unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
+       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.'}"
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "dict"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -370,7 +365,7 @@
    "source": [
     "#| export\n",
     "def chk_dest(p, ok_dests):\n",
-    "    resolved = str(Path(p).resolve())\n",
+    "    resolved = str(Path(p).expanduser().resolve())\n",
     "    if not any(resolved == (rd := str(Path(d).expanduser().resolve())) or resolved.startswith(rd + '/') for d in ok_dests):\n",
     "        raise PermissionError(f\"Dest '{p}' not allowed; permitted: {ok_dests}\")"
    ]
@@ -399,6 +394,7 @@
    ],
    "source": [
     "chk_dest('/tmp/foo.txt', ['/tmp'])\n",
+    "chk_dest('~/tmp/foo.txt', [Path.home()/'tmp'])\n",
     "try: chk_dest('/etc/passwd', ['/tmp'])\n",
     "except PermissionError: print(\"Correctly blocked /etc/passwd\")"
    ]
@@ -617,9 +613,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "list"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -1094,10 +1088,7 @@
    ]
   }
  ],
- "metadata": {
-  "solveit_dialog_mode": "concise",
-  "solveit_ver": 2
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/nbs/01_edit.ipynb
+++ b/nbs/01_edit.ipynb
@@ -131,9 +131,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "str"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -502,9 +500,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "tuple"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],
@@ -720,9 +716,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "Safe"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -92,9 +92,7 @@
       ]
      },
      "execution_count": null,
-     "metadata": {
-      "__type": "dict"
-     },
+     "metadata": {},
      "output_type": "execute_result"
     }
    ],

--- a/pyskills/core.py
+++ b/pyskills/core.py
@@ -66,7 +66,7 @@ def allow(*c, allow_policy=None): # Callable that raises if call not allowed
 
 # %% ../nbs/00_core.ipynb #a3124a91
 def chk_dest(p, ok_dests):
-    resolved = str(Path(p).resolve())
+    resolved = str(Path(p).expanduser().resolve())
     if not any(resolved == (rd := str(Path(d).expanduser().resolve())) or resolved.startswith(rd + '/') for d in ok_dests):
         raise PermissionError(f"Dest '{p}' not allowed; permitted: {ok_dests}")
 


### PR DESCRIPTION
Previously `chk_dest` was checking dest against `ok_dests` without expanding the user before `resolve()`, which was causing the following to fail, e.g when AI uses `~/...`:

```
chk_dest('~/tmp/foo.txt', [Path.home()/'tmp'])
```