### PR TITLE
fixes #9

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -33,7 +33,7 @@
     "from fastcore.xdg import *\n",
     "from importlib.metadata import entry_points\n",
     "from inspect import signature\n",
-    "import importlib.util, types, inspect, collections, ast, site"
+    "import importlib.util, types, inspect, collections, ast, site, shutil"
    ]
   },
   {
@@ -243,11 +243,11 @@
     {
      "data": {
       "text/plain": [
-       "{'dialoghelper.solveitskill': 'Read, search, edit, and manage Solveit dialogs using dialoghelper.core tools, including dialog/message addressing, line-numbered inspection, targeted message edits, add/update/delete/copy/paste workflows, and safe editing patterns.',\n",
+       "{'pyskills.edit': 'Text editing tools for modifying files and ipynb notebook cells. Each operation — insert, replace, delete lines, and string(s) replacement — has both a `file_*` and `cell_*` variant. All return unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
+       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.',\n",
+       " 'dialoghelper.solveitskill': 'Read, search, edit, and manage Solveit dialogs using dialoghelper.core tools, including dialog/message addressing, line-numbered inspection, targeted message edits, add/update/delete/copy/paste workflows, and safe editing patterns.',\n",
        " 'dialoghelper.termskill': 'Read and edit Solveit dialog (or Jupyter) .ipynb files from a CLI / script. Solveit is an online notebook application (like Jupyter with AI integration) where each notebook is called a \"dialog\" and is stored as an `.ipynb` file containing `code`, `note` (markdown), and `prompt` (markdown with a special delimiter) messages (aka \"cells\"). The `dialoghelper` package provides tools for reading, searching, adding, updating, and deleting those messages.',\n",
-       " 'exhash.skill': 'Universal hash-verified text editing for local files. Use this when an LLM needs one safe editing interface for reading, previewing, and modifying text files.',\n",
-       " 'pyskills.edit': 'Text editing tools for modifying files and ipynb notebook cells. Each operation — insert, replace, delete lines, and string(s) replacement — has both a `file_*` and `cell_*` variant. All return unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
-       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.'}"
+       " 'exhash.skill': 'Universal hash-verified text editing for local files. Use this when an LLM needs one safe editing interface for reading, previewing, and modifying text files.'}"
       ]
      },
      "execution_count": null,
@@ -614,7 +614,10 @@
     {
      "data": {
       "text/plain": [
-       "['SkillTestClass', 'skill_test_func', 'pyskills.createskill']"
+       "['SkillTestClass',\n",
+       " 'async_skill_test_func',\n",
+       " 'skill_test_func',\n",
+       " 'pyskills.createskill']"
       ]
      },
      "execution_count": null,
@@ -779,7 +782,7 @@
     "        elif callable(obj):\n",
     "            try: sig = str(signature(obj))\n",
     "            except (ValueError, TypeError): sig = '(...)'\n",
-    "            funcs.append(f'- def {name}{sig}{comment}')\n",
+    "            funcs.append(f'- {'async def' if inspect.iscoroutinefunction(obj) else 'def'} {name}{sig}{comment}')\n",
     "    if typs: parts += ['\\n## types:', *typs]\n",
     "    if funcs: parts += ['\\n## functions:', *funcs]\n",
     "    if subs: parts += ['\\n## submodules:', *subs]\n",
@@ -805,23 +808,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "## Creating pyskills\n",
-      "\n",
-      "`from pyskills import createskill; doc(createskill)` for how to build and register your own pyskill modules, including the allow/policy system.\n",
+      "ister your own pyskill modules, including the allow/policy system.\n",
       "\"\"\"\n",
       "\n",
       "## types:\n",
       "- class SkillTestClass(str): ...  # Some class.\n",
       "\n",
       "## functions:\n",
+      "- async def async_skill_test_func(x: int = 0) -> str: ...  # A test function\n",
       "- def skill_test_func(x: int = 0) -> str: ...  # A test function\n",
       "\n",
       "## submodules:\n",
       "  pyskills.createskill: ...  # How to create a pyskills pyskill module.\n",
       "\n",
       "## allows:\n",
-      "- allow(skill_test_func, SkillTestClass)\n"
+      "- allow(skill_test_func, async_skill_test_func, SkillTestClass)\n"
      ]
     }
    ],

--- a/nbs/01_edit.ipynb
+++ b/nbs/01_edit.ipynb
@@ -5,7 +5,6 @@
    "id": "4504a7cf",
    "metadata": {},
    "source": [
-    "#| export\n",
     "# pyskills.edit\n",
     "> Text editing tools for modifying files and ipynb notebook cells. Each operation — insert, replace, delete lines, and string(s) replacement — has both a `file_*` and `cell_*` variant. All return unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.\n",
     "> \n",
@@ -127,7 +126,7 @@
     {
      "data": {
       "text/plain": [
-       "'/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/tmph6_q2rka/test.txt'"
+       "'/var/folders/zl/js35kg3914qc7d8lsdtqsyf00000gn/T/tmpbijmuxs5/test.txt'"
       ]
      },
      "execution_count": null,
@@ -496,7 +495,7 @@
     {
      "data": {
       "text/plain": [
-       "('71121b93', '0bf7c681')"
+       "('4d191da1', 'ff731fd3')"
       ]
      },
      "execution_count": null,
@@ -712,7 +711,7 @@
     {
      "data": {
       "text/plain": [
-       "'<nb path=\"test.ipynb\"><code id=\"71121b93\">two\\nthree\\nGAMMA\\nDELTA</code><code id=\"0bf7c681\">other cell</code></nb>'"
+       "'<nb path=\"test.ipynb\"><code id=\"4d191da1\">two\\nthree\\nGAMMA\\nDELTA</code><code id=\"ff731fd3\">other cell</code></nb>'"
       ]
      },
      "execution_count": null,
@@ -788,7 +787,16 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "solveit": {
+   "default_code": true,
+   "mode": "learning",
+   "use_fence": false,
+   "use_thinking": false,
+   "use_tools": true,
+   "ver": 2
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/pyskills/core.py
+++ b/pyskills/core.py
@@ -14,7 +14,7 @@ from fastcore.docments import MarkdownRenderer,can_render
 from fastcore.xdg import *
 from importlib.metadata import entry_points
 from inspect import signature
-import importlib.util, types, inspect, collections, ast, site
+import importlib.util, types, inspect, collections, ast, site, shutil
 
 # %% ../nbs/00_core.ipynb #6dda45ba
 def ep_desc(ep):
@@ -214,7 +214,7 @@ def _doc_module(mod):
         elif callable(obj):
             try: sig = str(signature(obj))
             except (ValueError, TypeError): sig = '(...)'
-            funcs.append(f'- def {name}{sig}{comment}')
+            funcs.append(f'- {'async def' if inspect.iscoroutinefunction(obj) else 'def'} {name}{sig}{comment}')
     if typs: parts += ['\n## types:', *typs]
     if funcs: parts += ['\n## functions:', *funcs]
     if subs: parts += ['\n## submodules:', *subs]

--- a/pyskills/skill.py
+++ b/pyskills/skill.py
@@ -62,5 +62,11 @@ def skill_test_func(
     "A test function"
     return f"You call me with the arg: {x}"
 
-allow(skill_test_func, SkillTestClass)
+async def async_skill_test_func(
+    x:int=0 # the input
+)->str: # the output
+    "A test function"
+    return f"You call me with the arg: {x}"
+
+allow(skill_test_func, async_skill_test_func, SkillTestClass)
 


### PR DESCRIPTION
Currently `_doc_module` hardcodes function def which loses sync/async info and causes AI to not await an async function:

```py
funcs.append(f'- def {name}{sig}{comment}')
```

Also:

- Added missing `shutil` import
- Removed export marker from the first note msg in `edit` dialog which was causing it to appear twice in the docstring