### PR TITLE
Fix `allow()` registering decorated functions under the wrong module

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fastcore.test import test_eq,expect_fail"
+    "from fastcore.test import test,test_eq,expect_fail"
    ]
   },
   {
@@ -254,13 +254,13 @@
     {
      "data": {
       "text/plain": [
-       "{'dialoghelper.solveitskill': 'Read, search, edit, and manage Solveit dialogs using dialoghelper.core, including dialog/message addressing, line-numbered inspection, targeted message edits, add/update/delete/copy/paste workflows, and safe editing patterns.',\n",
+       "{'pyskills.edit': 'Functions for creating, reading, and modifying files. Each editing operation returns unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
+       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.',\n",
+       " 'dialoghelper.solveitskill': 'Read, search, edit, and manage Solveit dialogs using dialoghelper.core, including dialog/message addressing, line-numbered inspection, targeted message edits, add/update/delete/copy/paste workflows, and safe editing patterns.',\n",
        " 'dialoghelper.termskill': 'Read and edit Solveit dialog (or Jupyter) .ipynb files from a CLI / script. Solveit is an online notebook application (like Jupyter with AI integration) where each notebook is called a \"dialog\" and is stored as an `.ipynb` file containing `code`, `note` (markdown), and `prompt` (markdown with a special delimiter) messages (aka \"cells\"). The `dialoghelper` package provides tools for reading, searching, adding, updating, and deleting those messages.',\n",
        " 'exhash.skill': 'Universal hash-verified text editing for local files. Use this when an LLM needs one safe editing interface for reading, previewing, and modifying text files.',\n",
-       " 'bgtmux.skill': 'Use tmux-backed background terminal sessions from Solveit. Useful to have a persistent terminal session that both you and the user can inspect and edit, and that you can send input to from Solveit.',\n",
        " 'cordslite.skill': 'Load this skill when an agent needs to search, summarize, or find information in Discord using cordslite. It covers read-only workflows for connecting to Discord, opening a guild, orienting through channels, searching messages, reading threads, and fetching attachments.',\n",
-       " 'pyskills.edit': 'Functions for creating, reading, and modifying files. Each editing operation returns unified diffs showing what changed, or `\"none: No changes.\"`, or `\"error: ...\"`.',\n",
-       " 'pyskills.skill': 'Pyskills is a plugin system allowing Python packages to register \"skills\" (units of LLM-usable functionality) via standard Python entry points. An LLM host (e.g. solveit) discovers available pyskills without importing them, reads lightweight descriptions via AST inspection, and selectively loads chosen pyskills into context using standard imports.'}"
+       " 'repo.skill': 'Use this skill for repository investigation tasks involving local git history, GitHub PRs/issues/notifications, diffs, blame, code explanation, and source debugging.'}"
       ]
      },
      "execution_count": null,
@@ -340,8 +340,9 @@
     "                _set_wrapped(objclass, o.__name__, o)\n",
     "                continue\n",
     "            qualname = getattr(o, '__qualname__', '') or ''\n",
-    "            mod = sys.modules.get(getattr(o, '__globals__', {}).get('__name__'\n",
-    "                ) or getattr(o, '__module__', '__main__'), sys.modules.get('__main__'))\n",
+    "            ow = inspect.unwrap(o) if callable(o) else o\n",
+    "            mod = sys.modules.get(getattr(ow, '__globals__', {}).get('__name__'\n",
+    "                ) or getattr(ow, '__module__', '__main__'), sys.modules.get('__main__'))\n",
     "            if '.' in qualname:\n",
     "                cls = getattr(mod, qualname.rsplit('.', 1)[0], None)\n",
     "                if cls is not None:\n",
@@ -407,6 +408,28 @@
     "allow({httpx.get: chk_url, httpx.post: chk_url})\n",
     "assert ('get', chk_url) in __pytools__[httpx._api]\n",
     "assert ('post', chk_url) in __pytools__[httpx._api]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2230921",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastcore.xtras import timed_cache"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94625bdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _wrapped(): pass\n",
+    "allow(timed_cache(60)(_wrapped))\n",
+    "assert '_wrapped' in __pytools__[sys.modules['__main__']]"
    ]
   },
   {

--- a/pyskills/core.py
+++ b/pyskills/core.py
@@ -76,8 +76,9 @@ def allow(*c, allow_policy=None): # Callable that raises if call not allowed
                 _set_wrapped(objclass, o.__name__, o)
                 continue
             qualname = getattr(o, '__qualname__', '') or ''
-            mod = sys.modules.get(getattr(o, '__globals__', {}).get('__name__'
-                ) or getattr(o, '__module__', '__main__'), sys.modules.get('__main__'))
+            ow = inspect.unwrap(o) if callable(o) else o
+            mod = sys.modules.get(getattr(ow, '__globals__', {}).get('__name__'
+                ) or getattr(ow, '__module__', '__main__'), sys.modules.get('__main__'))
             if '.' in qualname:
                 cls = getattr(mod, qualname.rsplit('.', 1)[0], None)
                 if cls is not None:


### PR DESCRIPTION
`allow()` registered decorated functions (e.g. `@timed_cache`) under the wrapper's module instead of the original's, since it reads `__globals__['__name__']` which `@wraps` doesn't copy — so audit lookups (keyed on the real frame's `__main__`) missed and the call was wrongly denied. Fixed by `inspect.unwrap`ing before resolving the module, while still wrapping the original object.