### PR TITLE
Add files/ipynb entry points and clamp file_view line ranges

### DIFF
--- a/nbs/01_files.ipynb
+++ b/nbs/01_files.ipynb
@@ -65,8 +65,8 @@
     "    if not lines: return ''\n",
     "    if endline is None: endline = len(lines)\n",
     "    if endline < 0: endline = len(lines)+endline+1\n",
-    "    if not (1 <= startline <= len(lines)): return f'error: Invalid startline {startline}. Valid range: 1-{len(lines)}'\n",
-    "    if not (startline <= endline <= len(lines)): return f'error: Invalid endline {endline}. Valid range: {startline}-{len(lines)}'\n",
+    "    startline = min(max(1, startline), len(lines))\n",
+    "    endline = max(startline, min(endline, len(lines)))\n",
     "    return '\\n'.join(f'{i}: {l}' for i,l in enumerate(lines[startline-1:endline], startline))"
    ]
   },
@@ -79,10 +79,10 @@
     {
      "data": {
       "text/plain": [
-       "'/var/folders/51/b2_szf2945n072c0vj2cyty40000gn/T/tmp1z_mcg9e/test.txt'"
+       "'/var/folders/29/d2vp2sq93sb8j3k3fnkw805r0000gn/T/tmptk3mpiex/test.txt'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ Documentation = "https://AnswerDotAI.github.io/pyskills/"
 
 [project.entry-points.pyskills]
 "pyskills.skill" = "pyskills.skill"
+"pyskills.files" = "pyskills.files"
+"pyskills.ipynb" = "pyskills.ipynb"
 "pyskills.edit" = "pyskills.edit"
 
 [project.entry-points.nbdev]

--- a/pyskills/files.py
+++ b/pyskills/files.py
@@ -28,8 +28,8 @@ def file_view(
     if not lines: return ''
     if endline is None: endline = len(lines)
     if endline < 0: endline = len(lines)+endline+1
-    if not (1 <= startline <= len(lines)): return f'error: Invalid startline {startline}. Valid range: 1-{len(lines)}'
-    if not (startline <= endline <= len(lines)): return f'error: Invalid endline {endline}. Valid range: {startline}-{len(lines)}'
+    startline = min(max(1, startline), len(lines))
+    endline = max(startline, min(endline, len(lines)))
     return '\n'.join(f'{i}: {l}' for i,l in enumerate(lines[startline-1:endline], startline))
 
 # %% ../nbs/01_files.ipynb #106c65e3


### PR DESCRIPTION
## Changes

 - Added `pyskills.files` and `pyskills.ipynb` entry points to `pyproject.toml`
 - Replaced hard errors for invalid `startline`/`endline` in `file_view` with silent clamping, making the
 function more resilient to out-of-range inputs