### PR TITLE
Allow file handles in destination policies

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -564,11 +564,12 @@
     "    def __call__(self, obj, args, kwargs, data): raise NotImplementedError\n",
     "\n",
     "class PosAllowPolicy(AllowPolicy):\n",
-    "    \"Check positional/keyword arg is an allowed destination\"\n",
+    "    \"Check positional/keyword path arg is an allowed destination; non-path buffers/handles are skipped\"\n",
     "    def __init__(self, pos=0, kw=None): store_attr()\n",
     "    def __call__(self, obj, args, kwargs, data):\n",
     "        p = kwargs.get(self.kw) if self.kw and self.kw in kwargs else args[self.pos] if self.pos < len(args) else None\n",
-    "        if p is not None: chk_dest(p, data['ok_dests'])\n",
+    "        if isinstance(p, bytes): p = os.fsdecode(p)\n",
+    "        if isinstance(p, (str, os.PathLike)): chk_dest(p, data['ok_dests'])\n",
     "\n",
     "class PathWritePolicy(AllowPolicy):\n",
     "    \"Check resolved Path self, optionally also target args\"\n",
@@ -591,7 +592,7 @@
    "id": "3ba1b5d5",
    "metadata": {},
    "source": [
-    "Three `AllowPolicy` subclasses handle different allow-checking patterns."
+    "Three `AllowPolicy` subclasses handle different allow-checking patterns. `PosAllowPolicy` only checks str/`os.PathLike`/bytes arguments: callables like `DataFrame.to_excel` or openpyxl's `Workbook.save` also accept already-open file objects, whose destination was checked when they were opened — a policy crash on those would abort the run instead of denying it."
    ]
   },
   {
@@ -612,7 +613,13 @@
     "owp = OpenWritePolicy()\n",
     "owp(None, ['/tmp/f.txt', 'w'], {}, {'ok_dests': ['/tmp']})\n",
     "owp(None, ['/etc/passwd', 'r'], {}, {'ok_dests': ['/tmp']})\n",
-    "with expect_fail(PermissionError): owp(None, ['/root/f.txt', 'w'], {}, {'ok_dests': ['/tmp']})"
+    "with expect_fail(PermissionError): owp(None, ['/root/f.txt', 'w'], {}, {'ok_dests': ['/tmp']})\n",
+    "\n",
+    "import io\n",
+    "pp(None, ['src', io.BytesIO()], {}, {'ok_dests': ['/tmp']})\n",
+    "pp(None, ['src', open('/dev/null', 'wb')], {}, {'ok_dests': ['/tmp']})\n",
+    "pp(None, ['src', b'/tmp/ok'], {}, {'ok_dests': ['/tmp']})\n",
+    "with expect_fail(PermissionError): pp(None, ['src', b'/root/bad'], {}, {'ok_dests': ['/tmp']})"
    ]
   },
   {

--- a/pyskills/core.py
+++ b/pyskills/core.py
@@ -108,11 +108,12 @@ class AllowPolicy:
     def __call__(self, obj, args, kwargs, data): raise NotImplementedError
 
 class PosAllowPolicy(AllowPolicy):
-    "Check positional/keyword arg is an allowed destination"
+    "Check positional/keyword path arg is an allowed destination; non-path buffers/handles are skipped"
     def __init__(self, pos=0, kw=None): store_attr()
     def __call__(self, obj, args, kwargs, data):
         p = kwargs.get(self.kw) if self.kw and self.kw in kwargs else args[self.pos] if self.pos < len(args) else None
-        if p is not None: chk_dest(p, data['ok_dests'])
+        if isinstance(p, bytes): p = os.fsdecode(p)
+        if isinstance(p, (str, os.PathLike)): chk_dest(p, data['ok_dests'])
 
 class PathWritePolicy(AllowPolicy):
     "Check resolved Path self, optionally also target args"


### PR DESCRIPTION
`PosAllowPolicy` now checks string, `PathLike`, and byte paths while allowing already-open file handles and in-memory buffers. APIs such as `DataFrame.to_excel` and `Workbook.save` accept either paths or open file objects.

I wanted to use this instead of writing a special case for pandas. 

